### PR TITLE
(package) Update package metadata

### DIFF
--- a/src/Cake.Curl/Cake.Curl.csproj
+++ b/src/Cake.Curl/Cake.Curl.csproj
@@ -21,7 +21,7 @@
     <PackageProjectUrl>https://github.com/cake-contrib/Cake.Curl</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/cake-contrib/Cake.Curl</RepositoryUrl>
+    <RepositoryUrl>https://github.com/cake-contrib/Cake.Curl.git</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Based on a recent Twitter conversation:

https://twitter.com/adgrv/status/1127591787697061888

The suggestion is that the Repository URL should include the `.git` portion.